### PR TITLE
feat(auth): add blocking auth compliance gate for publish and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ jobs:
       - name: Lint
         run: make lint PYTHON=python
 
+      - name: Auth compliance checks
+        run: |
+          python -m skillforge auth-check --path . --json-out artifacts/auth-check.json
+
       - name: Test
         run: make test PYTHON=python
 

--- a/skillforge/cli.py
+++ b/skillforge/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import typer
 
+from skillforge.commands import auth_check as auth_check_command
 from skillforge.commands import generate as generate_command
 from skillforge.commands import init as init_command
 from skillforge.commands import publish as publish_command
@@ -38,6 +39,7 @@ app.command("generate")(generate_command.command)
 app.command("test")(test_command.command)
 app.command("publish")(publish_command.command)
 app.command("resolve-publishers")(resolve_publishers_command.command)
+app.command("auth-check")(auth_check_command.command)
 
 
 if __name__ == "__main__":

--- a/skillforge/commands/auth_check.py
+++ b/skillforge/commands/auth_check.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import typer
+
+TEXT_SUFFIXES = {
+    ".md",
+    ".txt",
+    ".rst",
+    ".yaml",
+    ".yml",
+    ".json",
+    ".env",
+    ".example",
+    ".py",
+    ".sh",
+    ".toml",
+}
+
+SKIP_DIRS = {
+    ".git",
+    ".venv",
+    ".pytest_cache",
+    ".ruff_cache",
+    "__pycache__",
+    "node_modules",
+    "tests",
+}
+
+AUTH001_PATTERNS = (
+    re.compile(r"export\s+SEREN_API_KEY\s*=", re.IGNORECASE),
+    re.compile(r"--api-key\s+[\"']?\$[{]?SEREN_API_KEY[}]?[\"']?", re.IGNORECASE),
+    re.compile(r"\b(set|configure)\s+SEREN_API_KEY\b", re.IGNORECASE),
+    re.compile(r"\b(create|get|copy|paste).{0,32}SEREN API key\b", re.IGNORECASE),
+)
+
+SEREN_KEY_ASSIGNMENT_RE = re.compile(r"\bSEREN_API_KEY\s*=\s*([^\s#]+)")
+
+SAFE_PLACEHOLDER_RE = re.compile(
+    r"^(\"?<[^>]+>\"?|\"?secret://[^\"]+\"?|\$\{?[A-Z0-9_]+\}?|\"?\")$"
+)
+
+
+class AuthCheckError(Exception):
+    """Raised when auth checks fail."""
+
+
+@dataclass(frozen=True)
+class AuthViolation:
+    rule_id: str
+    path: str
+    line: int
+    message: str
+
+
+@dataclass(frozen=True)
+class AuthCheckResult:
+    ok: bool
+    files_scanned: int
+    violations: tuple[AuthViolation, ...]
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                "ok": self.ok,
+                "files_scanned": self.files_scanned,
+                "violations": [asdict(violation) for violation in self.violations],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+
+
+def _is_text_file(path: Path) -> bool:
+    if path.suffix.lower() in TEXT_SUFFIXES:
+        return True
+    return path.name.endswith(".env.example")
+
+
+def _iter_text_files(root: Path) -> list[Path]:
+    if root.is_file():
+        return [root] if _is_text_file(root) else []
+
+    files: list[Path] = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        if any(part in SKIP_DIRS for part in path.parts):
+            continue
+        if _is_text_file(path):
+            files.append(path)
+    return files
+
+
+def _scan_file(path: Path, relative: Path) -> list[AuthViolation]:
+    text = path.read_text(encoding="utf-8", errors="ignore")
+    suffix = path.suffix.lower()
+    auth001_enabled = suffix in {".md", ".txt", ".rst", ".sh", ".yaml", ".yml"}
+    auth004_enabled = suffix in {
+        ".md",
+        ".txt",
+        ".rst",
+        ".sh",
+        ".yaml",
+        ".yml",
+        ".json",
+        ".env",
+        ".example",
+    } or path.name.endswith(".env.example")
+    violations: list[AuthViolation] = []
+    for idx, line in enumerate(text.splitlines(), start=1):
+        if auth001_enabled:
+            for pattern in AUTH001_PATTERNS:
+                if pattern.search(line):
+                    violations.append(
+                        AuthViolation(
+                            rule_id="AUTH001",
+                            path=relative.as_posix(),
+                            line=idx,
+                            message="Forbidden manual Seren auth setup instruction.",
+                        )
+                    )
+                    break
+
+        if auth004_enabled:
+            assignment = SEREN_KEY_ASSIGNMENT_RE.search(line)
+            if assignment:
+                value = assignment.group(1).strip().strip("'")
+                if value and not SAFE_PLACEHOLDER_RE.match(value):
+                    violations.append(
+                        AuthViolation(
+                            rule_id="AUTH004",
+                            path=relative.as_posix(),
+                            line=idx,
+                            message="Potential committed Seren credential-like value.",
+                        )
+                    )
+
+    return violations
+
+
+def run(path: Path) -> AuthCheckResult:
+    if not path.exists():
+        raise AuthCheckError(f"Path does not exist: {path}")
+
+    files = _iter_text_files(path)
+    violations: list[AuthViolation] = []
+    for file_path in files:
+        relative = file_path.relative_to(path) if path.is_dir() else file_path
+        violations.extend(_scan_file(file_path, relative))
+
+    return AuthCheckResult(
+        ok=not violations,
+        files_scanned=len(files),
+        violations=tuple(violations),
+    )
+
+
+def command(
+    path: Path = typer.Option(
+        Path("."),
+        "--path",
+        help="File or directory to scan for auth policy violations.",
+    ),
+    json_out: Path | None = typer.Option(
+        None,
+        "--json-out",
+        help="Optional path to write machine-readable rule results.",
+    ),
+) -> None:
+    try:
+        result = run(path=path)
+    except AuthCheckError as exc:
+        typer.echo(f"FAIL [auth-check] {exc}")
+        raise typer.Exit(code=1) from exc
+
+    if json_out is not None:
+        json_out.parent.mkdir(parents=True, exist_ok=True)
+        json_out.write_text(result.to_json(), encoding="utf-8")
+
+    if result.ok:
+        typer.echo(f"PASS [auth-check] scanned={result.files_scanned} violations=0")
+        return
+
+    typer.echo(
+        f"FAIL [auth-check] scanned={result.files_scanned} violations={len(result.violations)}"
+    )
+    for violation in result.violations:
+        typer.echo(
+            f"[{violation.rule_id}] {violation.path}:{violation.line}: {violation.message}"
+        )
+    raise typer.Exit(code=1)

--- a/skillforge/commands/publish.py
+++ b/skillforge/commands/publish.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 import typer
 
+from skillforge.commands import auth_check as auth_check_command
+
 REQUIRED_SOURCE_FILES = (
     Path("SKILL.md"),
     Path("scripts/agent.py"),
@@ -235,6 +237,20 @@ def run(
     shell: ShellAdapter | None = None,
 ) -> tuple[Path, str | None]:
     _ensure_source_layout(source)
+    auth_result = auth_check_command.run(path=source)
+    if not auth_result.ok:
+        preview = "\n".join(
+            f"[{violation.rule_id}] {violation.path}:{violation.line}: {violation.message}"
+            for violation in auth_result.violations[:10]
+        )
+        suffix = ""
+        if len(auth_result.violations) > 10:
+            suffix = f"\n... {len(auth_result.violations) - 10} more violation(s)"
+        raise PublishError(
+            "Auth policy violations detected in source artifacts.\n"
+            f"{preview}{suffix}\n"
+            "Run `skillforge auth-check --path <source>` to inspect all findings."
+        )
     _ensure_target_repo(target)
     _require_gh_cli(create_pr)
     _normalize_change_type(change_type)

--- a/tests/cli/test_auth_check_command.py
+++ b/tests/cli/test_auth_check_command.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from skillforge.cli import app
+
+runner = CliRunner()
+
+
+def test_auth_check_passes_for_safe_placeholders(tmp_path: Path) -> None:
+    (tmp_path / "SKILL.md").write_text(
+        "# Skill\n\nUse Desktop session auth. If needed, run `auth_bootstrap`.\n",
+        encoding="utf-8",
+    )
+    (tmp_path / ".env.example").write_text("SEREN_API_KEY=<required>\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["auth-check", "--path", str(tmp_path)])
+
+    assert result.exit_code == 0, result.output
+    assert "PASS [auth-check]" in result.output
+
+
+def test_auth_check_flags_manual_seren_api_key_setup(tmp_path: Path) -> None:
+    (tmp_path / "README.md").write_text(
+        "Setup:\nexport SEREN_API_KEY=abc123\n",
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["auth-check", "--path", str(tmp_path)])
+
+    assert result.exit_code != 0
+    assert "AUTH001" in result.output
+
+
+def test_auth_check_writes_json_report(tmp_path: Path) -> None:
+    (tmp_path / ".env.example").write_text("SEREN_API_KEY=sk-live-12345\n", encoding="utf-8")
+    report = tmp_path / "reports" / "auth-check.json"
+
+    result = runner.invoke(
+        app,
+        ["auth-check", "--path", str(tmp_path), "--json-out", str(report)],
+    )
+
+    assert result.exit_code != 0
+    payload = json.loads(report.read_text(encoding="utf-8"))
+    assert payload["ok"] is False
+    assert payload["violations"][0]["rule_id"] == "AUTH004"
+

--- a/tests/cli/test_publish_command.py
+++ b/tests/cli/test_publish_command.py
@@ -139,6 +139,36 @@ def test_publish_create_pr_fails_clearly_when_gh_missing(tmp_path: Path) -> None
     assert "gh CLI" in result.output
 
 
+def test_publish_blocks_when_auth_policy_violations_exist(tmp_path: Path) -> None:
+    source = _create_generated_source(tmp_path)
+    (source / "SKILL.md").write_text(
+        "# Skill\n\nRun `export SEREN_API_KEY=...` before starting.\n",
+        encoding="utf-8",
+    )
+    target_repo = tmp_path / "seren-skills"
+    target_repo.mkdir()
+    _init_git_repo(target_repo)
+
+    result = runner.invoke(
+        app,
+        [
+            "publish",
+            "--source",
+            str(source),
+            "--target",
+            str(target_repo),
+            "--org",
+            "curve",
+            "--name",
+            "gauge-reward-screener",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "Auth policy violations" in result.output
+    assert "AUTH001" in result.output
+
+
 class _RecordingShell(publish_command.ShellAdapter):
     def __init__(self) -> None:
         self.calls: list[list[str]] = []


### PR DESCRIPTION
## Summary
- add new `skillforge auth-check` command for auth policy scanning (`AUTH001`, `AUTH004`)
- block `skillforge publish` when source artifacts violate auth policy
- run auth-check in CI and emit JSON report
- add CLI coverage for auth-check and publish-gating behavior

## Validation
- `uv run ruff check skillforge/commands/auth_check.py skillforge/commands/publish.py skillforge/cli.py tests/cli/test_auth_check_command.py tests/cli/test_publish_command.py`
- `uv run python -m pytest tests/cli/test_auth_check_command.py tests/cli/test_publish_command.py`
- `uv run python -m skillforge auth-check --path . --json-out artifacts/auth-check.json`
