### PR TITLE
feat: add peer-to-peer payments exchange skill example

### DIFF
--- a/artifacts/peer-to-peer-payments-exchange/.env.example
+++ b/artifacts/peer-to-peer-payments-exchange/.env.example
@@ -1,0 +1,3 @@
+# Generated SkillForge environment template for peer-to-peer-payments-exchange
+SEREN_API_KEY=
+

--- a/artifacts/peer-to-peer-payments-exchange/SKILL.md
+++ b/artifacts/peer-to-peer-payments-exchange/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: peer-to-peer-payments-exchange
+description: "Route and execute peer-to-peer fiat-to-crypto payment and exchange flows on Peer (ZKP2P), including onramp, offramp, checkout, transfer, LP, vault, analytics, explorer, and activity monitoring paths."
+---
+
+# Peer To Peer Payments Exchange
+
+## When to Use
+
+- exchange fiat and usdc peer to peer
+- route p2p payment flow on peer protocol
+- orchestrate zkp2p checkout onramp offramp transfer
+
+## Workflow Summary
+
+1. `normalize_request` uses `transform.normalize_intent`
+2. `route_intent` uses `transform.route_intent`
+3. `get_market_quote` uses `connector.peer_market.get`
+4. `get_protocol_context` uses `connector.peer_analytics.get`
+5. `lookup_entity_context` uses `connector.peer_explorer.get`
+6. `build_execution_plan` uses `connector.model.post`
+7. `monitor_activity` uses `connector.peer_activity.get`
+8. `summary` uses `transform.render_guide`
+
+## Upstream Source
+
+- Repository: https://github.com/zkp2p/zkp2p-skills/
+
+## Referenced ZKP2P Skills
+
+### Action Skills
+
+- `accept-fiat-payments` -> receive fiat and settle USDC (`peer-checkout`)
+- `analyze-peer-protocol` -> protocol performance and health (`peer-analytics`)
+- `check-fx-rates` -> live rates/spreads/liquidity (`peer-market`)
+- `earn-as-defi-manager` -> vault management and strategy (`peer-vault`, `peer-rate-optimizer`)
+- `earn-on-idle-usdc` -> LP deposit and yield path (`peer-lp`)
+- `fiat-to-crypto` -> onramp fiat to USDC (`peer-onramp`)
+- `look-up-peer-data` -> entity/deposit/intent lookup (`peer-explorer`)
+- `monitor-peer-activity` -> live protocol event monitoring (`peer-activity`)
+- `pay-humans-fiat` -> offramp USDC to fiat payout (`peer-offramp`)
+- `send-usdc` -> direct USDC transfer (`peer-transfer`)
+
+### Implementation Skills
+
+- `peer-activity`
+- `peer-analytics`
+- `peer-checkout`
+- `peer-explorer`
+- `peer-lp`
+- `peer-market`
+- `peer-offramp`
+- `peer-onramp`
+- `peer-rate-optimizer`
+- `peer-transfer`
+- `peer-vault`

--- a/artifacts/peer-to-peer-payments-exchange/config.example.json
+++ b/artifacts/peer-to-peer-payments-exchange/config.example.json
@@ -1,0 +1,26 @@
+{
+  "connectors": [
+    "model",
+    "peer_activity",
+    "peer_analytics",
+    "peer_checkout",
+    "peer_explorer",
+    "peer_lp",
+    "peer_market",
+    "peer_offramp",
+    "peer_onramp",
+    "peer_rate_optimizer",
+    "peer_transfer",
+    "peer_vault"
+  ],
+  "dry_run": true,
+  "inputs": {
+    "amount_usd": 100,
+    "fiat_currency": "USD",
+    "include_analytics": true,
+    "intent": "check-fx-rates",
+    "live_mode": false,
+    "payment_platform": "wise"
+  },
+  "skill": "peer-to-peer-payments-exchange"
+}

--- a/artifacts/peer-to-peer-payments-exchange/scripts/agent.py
+++ b/artifacts/peer-to-peer-payments-exchange/scripts/agent.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Generated SkillForge runtime for peer-to-peer-payments-exchange."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+DEFAULT_DRY_RUN = True
+AVAILABLE_CONNECTORS = ['model', 'peer_activity', 'peer_analytics', 'peer_checkout', 'peer_explorer', 'peer_lp', 'peer_market', 'peer_offramp', 'peer_onramp', 'peer_rate_optimizer', 'peer_transfer', 'peer_vault']
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run generated SkillForge agent runtime.")
+    parser.add_argument(
+        "--config",
+        default="config.json",
+        help="Path to runtime config file (default: config.json).",
+    )
+    return parser.parse_args()
+
+
+def load_config(config_path: str) -> dict:
+    path = Path(config_path)
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def run_once(config: dict, dry_run: bool) -> dict:
+    return {
+        "status": "ok",
+        "dry_run": dry_run,
+        "connectors": AVAILABLE_CONNECTORS,
+        "input_keys": sorted(config.get("inputs", {}).keys()),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    config = load_config(args.config)
+    dry_run = bool(config.get("dry_run", DEFAULT_DRY_RUN))
+    result = run_once(config=config, dry_run=dry_run)
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/artifacts/peer-to-peer-payments-exchange/tests/fixtures/connector_failure.json
+++ b/artifacts/peer-to-peer-payments-exchange/tests/fixtures/connector_failure.json
@@ -1,0 +1,45 @@
+{
+  "status": "error",
+  "skill": "peer-to-peer-payments-exchange",
+  "error_code": "connector_failure",
+  "connector": "model",
+  "message": "Connector call failed during smoke test.",
+  "connectors": {
+    "model": {
+      "post": {
+        "status": "error",
+        "connector": "model",
+        "action": "post",
+        "error_code": "connector_failure"
+      }
+    },
+    "peer_activity": {
+      "get": {
+        "status": "ok",
+        "connector": "peer_activity",
+        "action": "get"
+      }
+    },
+    "peer_analytics": {
+      "get": {
+        "status": "ok",
+        "connector": "peer_analytics",
+        "action": "get"
+      }
+    },
+    "peer_explorer": {
+      "get": {
+        "status": "ok",
+        "connector": "peer_explorer",
+        "action": "get"
+      }
+    },
+    "peer_market": {
+      "get": {
+        "status": "ok",
+        "connector": "peer_market",
+        "action": "get"
+      }
+    }
+  }
+}

--- a/artifacts/peer-to-peer-payments-exchange/tests/fixtures/dry_run_guard.json
+++ b/artifacts/peer-to-peer-payments-exchange/tests/fixtures/dry_run_guard.json
@@ -1,0 +1,6 @@
+{
+  "status": "ok",
+  "skill": "peer-to-peer-payments-exchange",
+  "dry_run": true,
+  "blocked_action": "live_execution"
+}

--- a/artifacts/peer-to-peer-payments-exchange/tests/fixtures/happy_path.json
+++ b/artifacts/peer-to-peer-payments-exchange/tests/fixtures/happy_path.json
@@ -1,0 +1,51 @@
+{
+  "status": "ok",
+  "skill": "peer-to-peer-payments-exchange",
+  "workflow_step_count": 8,
+  "dry_run": true,
+  "inputs": {
+    "amount_usd": 100,
+    "fiat_currency": "USD",
+    "include_analytics": true,
+    "intent": "check-fx-rates",
+    "live_mode": false,
+    "payment_platform": "wise"
+  },
+  "connectors": {
+    "model": {
+      "post": {
+        "status": "ok",
+        "connector": "model",
+        "action": "post"
+      }
+    },
+    "peer_activity": {
+      "get": {
+        "status": "ok",
+        "connector": "peer_activity",
+        "action": "get"
+      }
+    },
+    "peer_analytics": {
+      "get": {
+        "status": "ok",
+        "connector": "peer_analytics",
+        "action": "get"
+      }
+    },
+    "peer_explorer": {
+      "get": {
+        "status": "ok",
+        "connector": "peer_explorer",
+        "action": "get"
+      }
+    },
+    "peer_market": {
+      "get": {
+        "status": "ok",
+        "connector": "peer_market",
+        "action": "get"
+      }
+    }
+  }
+}

--- a/artifacts/peer-to-peer-payments-exchange/tests/fixtures/policy_violation.json
+++ b/artifacts/peer-to-peer-payments-exchange/tests/fixtures/policy_violation.json
@@ -1,0 +1,7 @@
+{
+  "status": "error",
+  "skill": "peer-to-peer-payments-exchange",
+  "error_code": "policy_violation",
+  "policy": "max_notional_usd",
+  "message": "Requested notional exceeds configured cap."
+}

--- a/artifacts/peer-to-peer-payments-exchange/tests/test_smoke.py
+++ b/artifacts/peer-to-peer-payments-exchange/tests/test_smoke.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+def _read_fixture(name: str) -> dict:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_happy_path_fixture_is_successful() -> None:
+    payload = _read_fixture("happy_path.json")
+    assert payload["status"] == "ok"
+    assert payload["skill"] == "peer-to-peer-payments-exchange"
+
+
+def test_connector_failure_fixture_has_error_code() -> None:
+    payload = _read_fixture("connector_failure.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "connector_failure"
+
+
+def test_policy_violation_fixture_has_error_code() -> None:
+    payload = _read_fixture("policy_violation.json")
+    assert payload["status"] == "error"
+    assert payload["error_code"] == "policy_violation"
+
+
+def test_dry_run_fixture_blocks_live_execution() -> None:
+    payload = _read_fixture("dry_run_guard.json")
+    assert payload["dry_run"] is True
+    assert payload["blocked_action"] == "live_execution"
+

--- a/examples/peer-to-peer-payments-exchange/skill.spec.yaml
+++ b/examples/peer-to-peer-payments-exchange/skill.spec.yaml
@@ -1,0 +1,162 @@
+skill: peer-to-peer-payments-exchange
+description: Route and execute peer-to-peer fiat-to-crypto payment and exchange flows on Peer (ZKP2P), including onramp, offramp, checkout, transfer, LP, vault, analytics, explorer, and activity monitoring paths.
+triggers:
+  - exchange fiat and usdc peer to peer
+  - route p2p payment flow on peer protocol
+  - orchestrate zkp2p checkout onramp offramp transfer
+runtime:
+  language: python
+  entrypoint: scripts/agent.py
+inputs:
+  intent:
+    type: string
+    description: User intent key, for example fiat-to-crypto, pay-humans-fiat, accept-fiat-payments, send-usdc, or analyze-peer-protocol.
+    default: check-fx-rates
+  amount_usd:
+    type: number
+    min: 1
+    default: 100
+  fiat_currency:
+    type: string
+    default: USD
+  payment_platform:
+    type: string
+    default: wise
+  live_mode:
+    type: boolean
+    default: false
+  include_analytics:
+    type: boolean
+    default: true
+secrets:
+  - SEREN_API_KEY
+connectors:
+  peer_market:
+    kind: seren_publisher
+    publisher: peer-market
+  peer_checkout:
+    kind: seren_publisher
+    publisher: peer-checkout
+  peer_onramp:
+    kind: seren_publisher
+    publisher: peer-onramp
+  peer_offramp:
+    kind: seren_publisher
+    publisher: peer-offramp
+  peer_transfer:
+    kind: seren_publisher
+    publisher: peer-transfer
+  peer_lp:
+    kind: seren_publisher
+    publisher: peer-lp
+  peer_vault:
+    kind: seren_publisher
+    publisher: peer-vault
+  peer_rate_optimizer:
+    kind: seren_publisher
+    publisher: peer-rate-optimizer
+  peer_analytics:
+    kind: seren_publisher
+    publisher: peer-analytics
+  peer_explorer:
+    kind: seren_publisher
+    publisher: peer-explorer
+  peer_activity:
+    kind: seren_publisher
+    publisher: peer-activity
+  model:
+    kind: seren_publisher
+    publisher: seren-models
+state:
+  sessions:
+    kind: sqlite
+    file: state/peer_p2p_exchange.db
+policies:
+  dry_run_default: true
+  idempotency_required: true
+  max_daily_spend_usd: 50
+  max_notional_usd: 2000
+  max_slippage_bps: 150
+workflow:
+  steps:
+    - id: normalize_request
+      use: transform.normalize_intent
+      with:
+        intent: "{intent}"
+        amount_usd: "{amount_usd}"
+        fiat_currency: "{fiat_currency}"
+        payment_platform: "{payment_platform}"
+    - id: route_intent
+      use: transform.route_intent
+      with:
+        from_step: normalize_request
+        routes:
+          accept-fiat-payments: peer-checkout
+          analyze-peer-protocol: peer-analytics
+          check-fx-rates: peer-market
+          earn-as-defi-manager: peer-vault+peer-rate-optimizer
+          earn-on-idle-usdc: peer-lp
+          fiat-to-crypto: peer-onramp
+          look-up-peer-data: peer-explorer
+          monitor-peer-activity: peer-activity
+          pay-humans-fiat: peer-offramp
+          send-usdc: peer-transfer
+    - id: get_market_quote
+      use: connector.peer_market.get
+      with:
+        path: /quotes
+        amount_usd: "{amount_usd}"
+        fiat_currency: "{fiat_currency}"
+        payment_platform: "{payment_platform}"
+        from_step: route_intent
+    - id: get_protocol_context
+      use: connector.peer_analytics.get
+      with:
+        path: /summary
+        include_analytics: "{include_analytics}"
+        from_step: route_intent
+    - id: lookup_entity_context
+      use: connector.peer_explorer.get
+      with:
+        path: /search
+        from_step: normalize_request
+    - id: build_execution_plan
+      use: connector.model.post
+      with:
+        path: /v1/responses
+        body:
+          route_from: route_intent
+          market_from: get_market_quote
+          protocol_from: get_protocol_context
+          lookup_from: lookup_entity_context
+          live_mode: "{live_mode}"
+    - id: monitor_activity
+      use: connector.peer_activity.get
+      with:
+        path: /events
+        from_step: build_execution_plan
+    - id: summary
+      use: transform.render_guide
+      with:
+        from_step: monitor_activity
+        include_route_map: true
+tests:
+  quick:
+    - validates_intent_default
+    - validates_amount_bounds
+    - validates_safety_caps
+  smoke:
+    - routes_fiat_to_crypto_to_peer_onramp
+    - routes_pay_humans_to_peer_offramp
+    - generates_plan_with_analytics_context
+publish:
+  org: zkp2p
+  slug: peer-to-peer-payments-exchange
+metadata:
+  category: payments
+  protocol: peer-zkp2p
+  upstream_repo: https://github.com/zkp2p/zkp2p-skills
+  referenced_skills_count: "21"
+  referenced_action_skills: accept-fiat-payments,analyze-peer-protocol,check-fx-rates,earn-as-defi-manager,earn-on-idle-usdc,fiat-to-crypto,look-up-peer-data,monitor-peer-activity,pay-humans-fiat,send-usdc
+  referenced_implementation_skills: peer-activity,peer-analytics,peer-checkout,peer-explorer,peer-lp,peer-market,peer-offramp,peer-onramp,peer-rate-optimizer,peer-transfer,peer-vault
+  referenced_all_skills: accept-fiat-payments,analyze-peer-protocol,check-fx-rates,earn-as-defi-manager,earn-on-idle-usdc,fiat-to-crypto,look-up-peer-data,monitor-peer-activity,pay-humans-fiat,send-usdc,peer-activity,peer-analytics,peer-checkout,peer-explorer,peer-lp,peer-market,peer-offramp,peer-onramp,peer-rate-optimizer,peer-transfer,peer-vault

--- a/tests/schema/test_schema_examples.py
+++ b/tests/schema/test_schema_examples.py
@@ -13,6 +13,7 @@ VALID_EXAMPLES = [
     REPO_ROOT / "examples/browser-automation/skill.spec.yaml",
     REPO_ROOT / "examples/polymarket-trader/skill.spec.yaml",
     REPO_ROOT / "examples/customer-support-intake/skill.spec.yaml",
+    REPO_ROOT / "examples/peer-to-peer-payments-exchange/skill.spec.yaml",
 ]
 INVALID_FIXTURES = [
     REPO_ROOT / "tests/schema/fixtures/invalid_missing_required.yaml",


### PR DESCRIPTION
## Summary
- add new `peer-to-peer-payments-exchange` example spec
- add generated artifact bundle with skill docs, config/env examples, script, and smoke tests
- register the new example in schema validation tests

## Validation
- pytest -q tests/schema/test_schema_examples.py
- pytest -q artifacts/peer-to-peer-payments-exchange/tests/test_smoke.py
