### PR TITLE
feat(release): add default seren-skills release path

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,13 @@ python -m skillforge validate --spec examples/minimal/skill.spec.yaml
 python -m skillforge validate --spec examples/polymarket-trader/skill.spec.yaml --online-publishers --require-api-key
 python -m skillforge resolve-publishers --spec examples/polymarket-trader/skill.spec.yaml --check --require-api-key
 python -m skillforge resolve-publishers --spec examples/polymarket-trader/skill.spec.yaml --write --require-api-key
+python -m skillforge release --spec examples/browser-automation/skill.spec.yaml --target ../seren-skills
+python -m skillforge release --spec examples/polymarket-trader/skill.spec.yaml --target ../seren-skills --resolve-publishers --require-api-key --create-pr
 python -m skillforge generate --spec examples/minimal/skill.spec.yaml --out /tmp/skillforge-out
-python -m skillforge generate --spec examples/polymarket-trader/skill.spec.yaml --out /tmp/skillforge-out --resolve-publishers --require-api-key
 python -m skillforge test --mode quick --spec examples/minimal/skill.spec.yaml
 ```
+
+`release` is the default shipping path. It generates artifacts into a temporary directory, publishes them into a local `seren-skills` clone using `publish.org` and `publish.slug` from the spec, and can open the destination PR with `--create-pr`.
 
 ## Publisher Guardrails
 

--- a/docs/architecture/0002_publish_workflow.md
+++ b/docs/architecture/0002_publish_workflow.md
@@ -4,6 +4,8 @@
 
 Define how SkillForge syncs generated artifacts into a local `seren-skills` clone with safe defaults.
 
+Most users should ship skills through `skillforge release`, which generates into a temporary directory and then delegates to `publish`. The `publish` command remains the lower-level sync primitive.
+
 ## Scope
 
 The `publish` command handles:

--- a/skillforge/cli.py
+++ b/skillforge/cli.py
@@ -7,6 +7,7 @@ import typer
 from skillforge.commands import generate as generate_command
 from skillforge.commands import init as init_command
 from skillforge.commands import publish as publish_command
+from skillforge.commands import release as release_command
 from skillforge.commands import resolve_publishers as resolve_publishers_command
 from skillforge.commands import test as test_command
 from skillforge.commands import validate as validate_command
@@ -15,7 +16,7 @@ app = typer.Typer(
     name="skillforge",
     no_args_is_help=True,
     add_completion=False,
-    help="SkillForge CLI for generating and validating skills from SkillSpec.",
+    help="SkillForge CLI for generating, validating, and releasing skills from SkillSpec.",
 )
 
 
@@ -37,6 +38,7 @@ app.command("validate")(validate_command.command)
 app.command("generate")(generate_command.command)
 app.command("test")(test_command.command)
 app.command("publish")(publish_command.command)
+app.command("release")(release_command.command)
 app.command("resolve-publishers")(resolve_publishers_command.command)
 
 

--- a/skillforge/commands/generate.py
+++ b/skillforge/commands/generate.py
@@ -18,6 +18,10 @@ from skillforge.parser import parse_spec
 from skillforge.publisher_catalog import DEFAULT_GATEWAY_URL
 
 
+class GenerateError(Exception):
+    """Raised when generation cannot complete."""
+
+
 def _render_outputs(spec_path: Path) -> dict[Path, str]:
     parsed = parse_spec(spec_path)
     spec = parsed.ir
@@ -57,6 +61,67 @@ def _write_outputs(*, out_dir: Path, outputs: dict[Path, str]) -> list[Path]:
     return written_paths
 
 
+def run(
+    *,
+    spec: Path,
+    out: Path,
+    check: bool,
+    resolve_publishers: bool,
+    gateway_url: str,
+    api_key_env: str,
+    require_api_key: bool,
+) -> list[Path]:
+    if resolve_publishers:
+        resolved = resolve_publishers_command.run(
+            spec=spec,
+            gateway_url=gateway_url,
+            api_key_env=api_key_env,
+            require_api_key=require_api_key,
+            allow_inactive=False,
+            write=False,
+        )
+        if not resolved.ok:
+            lines = [
+                f"FAIL [generate] publisher resolution failed catalog={resolved.catalog_size}",
+                *(
+                    f"[{issue.code}] {issue.path}: {issue.message}"
+                    for issue in resolved.issues
+                ),
+            ]
+            raise GenerateError("\n".join(lines))
+        if resolved.changes:
+            lines = [
+                f"FAIL [generate] unresolved publisher slugs={len(resolved.changes)}. "
+                "Run `skillforge resolve-publishers --write` first.",
+                *(
+                    f"{change.connector}: {change.from_slug or '<empty>'} -> "
+                    f"{change.to_slug} ({change.source})"
+                    for change in resolved.changes
+                ),
+            ]
+            raise GenerateError("\n".join(lines))
+
+    validation = validate_command.run(spec=spec)
+    if not validation.ok:
+        lines = [
+            f"FAIL [generate] spec validation failed checks={validation.checks_run}",
+            *validate_command.format_failures(validation),
+        ]
+        raise GenerateError("\n".join(lines))
+
+    outputs = _render_outputs(spec)
+
+    if check:
+        stale = _stale_paths(out_dir=out, outputs=outputs)
+        if stale:
+            lines = [f"FAIL [generate --check] stale outputs: {len(stale)}"]
+            lines.extend(relative_path.as_posix() for relative_path in stale)
+            raise GenerateError("\n".join(lines))
+        return []
+
+    return _write_outputs(out_dir=out, outputs=outputs)
+
+
 def command(
     spec: Path = typer.Option(
         Path("skill.spec.yaml"),
@@ -94,52 +159,22 @@ def command(
         help="Fail if publisher resolution is enabled and API key env var is missing.",
     ),
 ) -> None:
-    if resolve_publishers:
-        resolved = resolve_publishers_command.run(
+    try:
+        written_paths = run(
             spec=spec,
+            out=out,
+            check=check,
+            resolve_publishers=resolve_publishers,
             gateway_url=gateway_url,
             api_key_env=api_key_env,
             require_api_key=require_api_key,
-            allow_inactive=False,
-            write=False,
         )
-        if not resolved.ok:
-            typer.echo(
-                f"FAIL [generate] publisher resolution failed catalog={resolved.catalog_size}"
-            )
-            for issue in resolved.issues:
-                typer.echo(f"[{issue.code}] {issue.path}: {issue.message}")
-            raise typer.Exit(code=1)
-        if resolved.changes:
-            typer.echo(
-                f"FAIL [generate] unresolved publisher slugs={len(resolved.changes)}. "
-                "Run `skillforge resolve-publishers --write` first."
-            )
-            for change in resolved.changes:
-                typer.echo(
-                    f"{change.connector}: {change.from_slug or '<empty>'} -> "
-                    f"{change.to_slug} ({change.source})"
-                )
-            raise typer.Exit(code=1)
-
-    validation = validate_command.run(spec=spec)
-    if not validation.ok:
-        typer.echo(f"FAIL [generate] spec validation failed checks={validation.checks_run}")
-        validate_command.print_failures(validation)
-        raise typer.Exit(code=1)
-
-    outputs = _render_outputs(spec)
+    except GenerateError as exc:
+        typer.echo(str(exc))
+        raise typer.Exit(code=1) from exc
 
     if check:
-        stale = _stale_paths(out_dir=out, outputs=outputs)
-        if stale:
-            typer.echo(f"FAIL [generate --check] stale outputs: {len(stale)}")
-            for relative_path in stale:
-                typer.echo(relative_path.as_posix())
-            raise typer.Exit(code=1)
-
         typer.echo("PASS [generate --check] outputs are up-to-date")
         return
 
-    written_paths = _write_outputs(out_dir=out, outputs=outputs)
     typer.echo(f"Generated {len(written_paths)} files in {out}")

--- a/skillforge/commands/release.py
+++ b/skillforge/commands/release.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import typer
+
+from skillforge.commands import generate as generate_command
+from skillforge.commands import publish as publish_command
+from skillforge.parser import SkillSpecParseError, parse_spec
+from skillforge.publisher_catalog import DEFAULT_GATEWAY_URL
+
+
+class ReleaseError(Exception):
+    """Raised when release cannot complete safely."""
+
+
+def _load_publish_target(spec: Path) -> tuple[str, str]:
+    try:
+        parsed = parse_spec(spec)
+    except SkillSpecParseError as exc:
+        lines = [f"Failed to parse spec: {exc}"]
+        lines.extend(f"[{item.path}] {item.message}" for item in exc.diagnostics)
+        raise ReleaseError("\n".join(lines)) from exc
+
+    publish = parsed.ir.publish
+    if publish is None:
+        raise ReleaseError(
+            f"Spec {spec} is missing publish metadata. Add publish.org and publish.slug."
+        )
+    return publish["org"], publish["slug"]
+
+
+def run(
+    *,
+    spec: Path,
+    target: Path,
+    force: bool,
+    create_pr: bool,
+    base_branch: str,
+    branch_name: str | None,
+    change_type: str,
+    scope: str | None,
+    resolve_publishers: bool,
+    gateway_url: str,
+    api_key_env: str,
+    require_api_key: bool,
+) -> tuple[Path, str | None]:
+    org, name = _load_publish_target(spec)
+
+    try:
+        with tempfile.TemporaryDirectory(prefix="skillforge-release-") as tmp_dir:
+            source = Path(tmp_dir)
+            generate_command.run(
+                spec=spec,
+                out=source,
+                check=False,
+                resolve_publishers=resolve_publishers,
+                gateway_url=gateway_url,
+                api_key_env=api_key_env,
+                require_api_key=require_api_key,
+            )
+            return publish_command.run(
+                source=source,
+                target=target,
+                org=org,
+                name=name,
+                force=force,
+                create_pr=create_pr,
+                base_branch=base_branch,
+                branch_name=branch_name,
+                change_type=change_type,
+                scope=scope,
+            )
+    except generate_command.GenerateError as exc:
+        raise ReleaseError(str(exc)) from exc
+    except publish_command.PublishError as exc:
+        raise ReleaseError(str(exc)) from exc
+
+
+def command(
+    spec: Path = typer.Option(
+        Path("skill.spec.yaml"),
+        "--spec",
+        help="Path to skill.spec.yaml.",
+    ),
+    target: Path = typer.Option(
+        ...,
+        "--target",
+        help="Path to local seren-skills git clone.",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Allow overwriting an existing target skill directory.",
+    ),
+    create_pr: bool = typer.Option(
+        False,
+        "--create-pr",
+        help="Create a pull request via gh after releasing.",
+    ),
+    base_branch: str = typer.Option(
+        "main",
+        "--base-branch",
+        help="Base branch to target when creating a pull request.",
+    ),
+    branch_name: str | None = typer.Option(
+        None,
+        "--branch-name",
+        help="Optional branch name override for PR creation.",
+    ),
+    change_type: str = typer.Option(
+        "feat",
+        "--change-type",
+        help=(
+            "Conventional type for commit message and PR title "
+            "(feat|fix|docs|chore|refactor|test)."
+        ),
+    ),
+    scope: str | None = typer.Option(
+        None,
+        "--scope",
+        help="Optional conventional scope for commit message and PR title.",
+    ),
+    resolve_publishers: bool = typer.Option(
+        False,
+        "--resolve-publishers/--no-resolve-publishers",
+        help="Require connectors to resolve against live publisher catalog before release.",
+    ),
+    gateway_url: str = typer.Option(
+        DEFAULT_GATEWAY_URL,
+        "--gateway-url",
+        help="Seren gateway base URL for publisher resolution.",
+    ),
+    api_key_env: str = typer.Option(
+        "SEREN_API_KEY",
+        "--api-key-env",
+        help="Environment variable name for optional Bearer API key.",
+    ),
+    require_api_key: bool = typer.Option(
+        False,
+        "--require-api-key",
+        help="Fail if publisher resolution is enabled and API key env var is missing.",
+    ),
+) -> None:
+    try:
+        destination, pr_url = run(
+            spec=spec,
+            target=target,
+            force=force,
+            create_pr=create_pr,
+            base_branch=base_branch,
+            branch_name=branch_name,
+            change_type=change_type,
+            scope=scope,
+            resolve_publishers=resolve_publishers,
+            gateway_url=gateway_url,
+            api_key_env=api_key_env,
+            require_api_key=require_api_key,
+        )
+    except ReleaseError as exc:
+        typer.echo(f"FAIL [release] {exc}")
+        raise typer.Exit(code=1) from exc
+
+    typer.echo(f"Released {spec} -> {destination}")
+    if pr_url:
+        typer.echo(f"Opened PR: {pr_url}")

--- a/skillforge/commands/validate.py
+++ b/skillforge/commands/validate.py
@@ -144,8 +144,12 @@ def run(
 
 
 def print_failures(result: HarnessResult) -> None:
-    for failure in result.failures:
-        typer.echo(f"[{failure.code}] {failure.path}: {failure.message}")
+    for line in format_failures(result):
+        typer.echo(line)
+
+
+def format_failures(result: HarnessResult) -> list[str]:
+    return [f"[{failure.code}] {failure.path}: {failure.message}" for failure in result.failures]
 
 
 def command(

--- a/tests/cli/test_release_command.py
+++ b/tests/cli/test_release_command.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from skillforge.cli import app
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+runner = CliRunner()
+
+
+def _init_git_repo(path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True, text=True)
+    (path / "README.md").write_text("# temp repo\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=path, check=True, capture_output=True, text=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=SkillForge Test",
+            "-c",
+            "user.email=skillforge@example.com",
+            "commit",
+            "-m",
+            "init",
+        ],
+        cwd=path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_release_generates_and_publishes_from_spec_metadata(tmp_path: Path) -> None:
+    target_repo = tmp_path / "seren-skills"
+    target_repo.mkdir()
+    _init_git_repo(target_repo)
+
+    result = runner.invoke(
+        app,
+        [
+            "release",
+            "--spec",
+            str(REPO_ROOT / "examples/browser-automation/skill.spec.yaml"),
+            "--target",
+            str(target_repo),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    published_dir = target_repo / "seren" / "browser-automation"
+    assert (published_dir / "SKILL.md").exists()
+    assert (published_dir / "requirements.txt").exists()
+    assert (published_dir / "scripts" / "agent.py").exists()
+    assert "Released" in result.output
+
+
+def test_release_requires_publish_metadata(tmp_path: Path) -> None:
+    target_repo = tmp_path / "seren-skills"
+    target_repo.mkdir()
+    _init_git_repo(target_repo)
+
+    result = runner.invoke(
+        app,
+        [
+            "release",
+            "--spec",
+            str(REPO_ROOT / "examples/minimal/skill.spec.yaml"),
+            "--target",
+            str(target_repo),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "missing publish metadata" in result.output


### PR DESCRIPTION
## Summary
- add a `skillforge release` command that generates to a temporary directory and publishes into a local `seren-skills` clone using spec metadata
- refactor `generate` into a reusable `run(...)` path so release reuses existing generation logic
- document `release` as the default shipping workflow

Fixes #27

## Testing
- `/Users/taariqlewis/Projects/Seren_Projects/seren-skillforge/.venv/bin/python -m pytest tests/cli/test_release_command.py tests/cli/test_generate_command.py tests/cli/test_publish_command.py`
- `/Users/taariqlewis/Projects/Seren_Projects/seren-skillforge/.venv/bin/python -m ruff check skillforge/commands/validate.py skillforge/commands/generate.py skillforge/commands/release.py skillforge/cli.py tests/cli/test_release_command.py`
- `/Users/taariqlewis/Projects/Seren_Projects/seren-skillforge/.venv/bin/python -m skillforge release --help`
